### PR TITLE
Add `similarGroups` public method

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ console.log(c.groups(3));
 // >   [ 'stephanie', 'stephen' ] ]
 ```
 
+Divide into any number of groups each with at least 50% similarity:
+```javascript
+console.log(c.similarGroups(0.5));
+// > [ [ 'norbert', 'albert' ],
+// >   [ 'bernard' ],
+// >   [ 'stephanie', 'stephen' ] ]
+```
+
 ## Long example, grouping a set of tagged articles:
 ```javascript
 var cluster = require('set-clustering');
@@ -134,6 +142,7 @@ console.log(titles);
 * [groups](#groups)
 * [representatives](#representatives)
 * [evenGroups](#evenGroups)
+* [similarGroups](#similarGroups)
 
 -----------------------------------
 
@@ -145,6 +154,7 @@ Returns a new `cluster` instance, which is an object with 3 functions:
 * [groups](#groups)
 * [representatives](#representatives)
 * [evenGroups](#evenGroups)
+* [similarGroups](#similarGroups)
 
 __Arguments__
 
@@ -247,6 +257,37 @@ console.log(g);
 
 // [ [1, 2, 3, 4],
 //   [5, 23, 24, 25] ]
+```
+
+-----------------------------------
+
+<a name="similarGroups" />
+## similarGroups(similarityIndex)
+
+Like [groups(howMany)](#groups) but useful when you care about how similar
+items in a group are instead of how many groups you end up with.
+
+Returns 1 to `n` number of groups, where the `n` is the number of elements
+in the cluster.  Return value is an `Array` of `Array`s.
+
+__Arguments__
+
+* similarityIndex - Similarity index to group the elements by.  Must be `>= 0` and `<= 1`.
+
+__Example__
+
+```javascript
+var c = cluster(
+    [1, 2, 3, 4, 5, 23, 24, 25],
+    function quadraticDropOff(e1, e2) { return 1 / Math.pow(e1 - e2, 2); }
+);
+
+var g = c.similarGroups(0.5);
+
+console.log(g);
+
+// [ [25, 24, 23],
+//   [5, 4, 3, 2, 1] ]
 ```
 
 -----------------------------------

--- a/cluster.js
+++ b/cluster.js
@@ -48,6 +48,11 @@ module.exports = function(set, similarity) {
     return roots;
   }
 
+  function similarGroups(similarityIndex) {
+    var subGraphs = graph.connected(g, similarityIndex);
+    return subGraphs;
+  }
+
   function evenGroups(numGroups, searchDepth_) {
     var roots = representatives(numGroups);
     var divisions = graph.growFromNuclei(g, roots);
@@ -68,6 +73,7 @@ module.exports = function(set, similarity) {
   return {
     groups: stripGraphs(groups),
     representatives: stripNodes(representatives),
+    similarGroups: stripGraphs(similarGroups),
     evenGroups: evenGroups
   };
 }

--- a/test/base.js
+++ b/test/base.js
@@ -36,6 +36,13 @@ describe('set-clustering can be used as described', function() {
     });
   });
 
+  it('can be asked for similar groups', function() {
+    assert.doesNotThrow(function() {
+      var c = cluster([1], function similarity() { return 0; });
+      c.similarGroups(0.5);
+    });
+  });
+
   it('can group 3 items into 3 groups', function() {
     assert.doesNotThrow(function() {
       var c = cluster([1, 2, 3], function similarity() { return 0; });
@@ -52,6 +59,16 @@ describe('set-clustering can be used as described', function() {
       assert.equal(g[0].length, 2);
       assert.equal(g[1].length, 2);
       assert.equal(g[2].length, 2);
+    });
+  });
+
+  it('can distribute 6 items into 2 similar groups', function () {
+    assert.doesNotThrow(function() {
+      var c = cluster([1, 2, 3, 4, 5, 6], function similarity(x, y) { return (x % 2 === y % 2) ? 1 : 0 });
+      var g = c.similarGroups(0.5);
+      assert.equal(g.length, 2);
+      assert.equal(g[0].length, 3);
+      assert.equal(g[1].length, 3);
     });
   });
 

--- a/test/examples.js
+++ b/test/examples.js
@@ -34,6 +34,17 @@ describe('set-clustering behaves according to examples', function() {
     ));
   });
 
+  it('divides names into similar groups, based on edit distance', function() {
+    var c = cluster(example1words, editDistancePercentage).similarGroups(0.5);
+
+    assert(deepUnorderedEquals(
+      c,
+      [ [ 'norbert', 'albert' ],
+        [ 'bernard' ],
+        [ 'stephanie', 'stephen' ] ]
+    ));
+  });
+
   it('divides articles into 5 groups, based on tag similarity', function() {
     var articles = [
       { title: "The Last Federation beginner strategy guide",


### PR DESCRIPTION
I found your library very useful, but sometimes I wished I could just create any number of groups based on a certain similarity threshold. This PR adds that method, `similarGroups`, which takes an edge length (similarity index) at which to stop removing weak edges.

- [X] Method
- [X] Readme
- [X] Tests